### PR TITLE
Feature/au 01

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,0 +1,19 @@
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        padding: "2rem 1.5rem",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -23,12 +23,6 @@ export default function RegisterPage() {
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError("");
-
-    if (form.password !== form.passwordConfirm) {
-      setError("비밀번호가 일치하지 않습니다.");
-      return;
-    }
-
     setIsLoading(true);
     try {
       await fetchApi("/api/users/signup", {

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { fetchApi } from "@/lib/client";
+import { SignupReq } from "@/type/user";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [form, setForm] = useState<SignupReq>({
+    username: "",
+    password: "",
+    passwordConfirm: "",
+    nickname: "",
+  });
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (form.password !== form.passwordConfirm) {
+      setError("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await fetchApi("/api/users/signup", {
+        method: "POST",
+        body: JSON.stringify(form),
+      });
+      alert("회원가입이 완료되었습니다.");
+      router.push("/login");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "회원가입에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <h1
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          marginBottom: "2rem",
+          textAlign: "center",
+          color: "var(--text-primary)",
+        }}
+      >
+        회원가입
+      </h1>
+
+      <form
+        onSubmit={onSubmit}
+        style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+      >
+        <input
+          type="text"
+          name="username"
+          placeholder="아이디"
+          value={form.username}
+          onChange={onChange}
+          required
+          style={inputStyle}
+        />
+        <input
+          type="password"
+          name="password"
+          placeholder="비밀번호"
+          value={form.password}
+          onChange={onChange}
+          required
+          style={inputStyle}
+        />
+        <input
+          type="password"
+          name="passwordConfirm"
+          placeholder="비밀번호 확인"
+          value={form.passwordConfirm}
+          onChange={onChange}
+          required
+          style={inputStyle}
+        />
+        <input
+          type="text"
+          name="nickname"
+          placeholder="닉네임"
+          value={form.nickname}
+          onChange={onChange}
+          required
+          style={inputStyle}
+        />
+
+        {error && (
+          <p style={{ color: "var(--price-up)", fontSize: "0.875rem", textAlign: "center" }}>
+            {error}
+          </p>
+        )}
+
+        <button type="submit" disabled={isLoading} style={buttonStyle}>
+          {isLoading ? "처리 중..." : "회원가입"}
+        </button>
+      </form>
+
+      <p
+        style={{
+          marginTop: "1.5rem",
+          textAlign: "center",
+          fontSize: "0.875rem",
+          color: "var(--text-tertiary)",
+        }}
+      >
+        이미 계정이 있으신가요?{" "}
+        <a href="/login" style={{ color: "var(--accent-primary)", fontWeight: 600 }}>
+          로그인
+        </a>
+      </p>
+    </>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: "0.75rem 1rem",
+  borderRadius: "0.5rem",
+  border: "1px solid var(--border-soft)",
+  background: "var(--bg-card)",
+  fontSize: "1rem",
+  color: "var(--text-primary)",
+  outline: "none",
+  width: "100%",
+};
+
+const buttonStyle: React.CSSProperties = {
+  marginTop: "0.5rem",
+  padding: "0.875rem",
+  borderRadius: "0.5rem",
+  background: "var(--accent-primary)",
+  color: "#fff",
+  fontWeight: 700,
+  fontSize: "1rem",
+  cursor: "pointer",
+  opacity: 1,
+};

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import Link from "next/link";
 import { fetchApi } from "@/lib/client";
 import { SignupReq } from "@/type/user";
 
@@ -113,9 +114,9 @@ export default function RegisterPage() {
         }}
       >
         이미 계정이 있으신가요?{" "}
-        <a href="/login" style={{ color: "var(--accent-primary)", fontWeight: 600 }}>
+        <Link href="/login" style={{ color: "var(--accent-primary)", fontWeight: 600 }}>
           로그인
-        </a>
+        </Link>
       </p>
     </>
   );

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -7,11 +7,6 @@ export function fetchApi(url: string, options?: RequestInit) {
     headers.set("Content-Type", "application/json");
   }
 
-  const accessToken = localStorage.getItem("accessToken");
-  if (accessToken) {
-    headers.set("Authorization", `Bearer ${accessToken}`);
-  }
-
   options.headers = headers;
 
   return fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, options).then(

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,0 +1,26 @@
+export function fetchApi(url: string, options?: RequestInit) {
+  options = options || {};
+
+  const headers = new Headers(options.headers || {});
+
+  if (options.body) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const accessToken = localStorage.getItem("accessToken");
+  if (accessToken) {
+    headers.set("Authorization", `Bearer ${accessToken}`);
+  }
+
+  options.headers = headers;
+
+  return fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, options).then(
+    async (res) => {
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.message ?? "요청에 실패했습니다.");
+      }
+      return res.json();
+    }
+  );
+}

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -1,0 +1,11 @@
+export type SignupReq = {
+  username: string;
+  password: string;
+  passwordConfirm: string;
+  nickname: string;
+};
+
+export type UsersRes = {
+  accessToken: string;
+  refreshToken: string;
+};


### PR DESCRIPTION
## 📌 과제 설명
- 회원가입 기능 구현 및 백엔드 API 연동

## 👩‍💻 요구 사항과 구현 내용
- 유저 타입 정의 추가
  - `SignupReq`, `UsersRes` 타입 정의
- fetchApi 클라이언트 래퍼 추가
  - 에러 처리 포함 일단 body 전송으로 진행하지만 추후 시큐리티 연동 시 bearer 헤더 방식으로 변경 예정
- 회원가입 페이지 구현
  - 회원가입 폼 UI 및 `POST /api/users/signup` 연동

## ✅ PR 포인트 & 궁금한 점
- fetch 래퍼를 만들어서 모든 API 호출에서 재사용합니다.
- a 태그 대신 훨씬 빠른 Link 태그로 사용했습니다.