### PR TITLE
Feature/au 03

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import Link from "next/link";
+import { fetchApi } from "@/lib/client";
+import { UsersRes } from "@/type/user";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setIsLoading(true);
+    try {
+      const { accessToken, refreshToken } = await fetchApi("/api/users/login", {
+        method: "POST",
+        body: JSON.stringify({ username, password }),
+      }) as UsersRes;
+      localStorage.setItem("accessToken", accessToken);
+      localStorage.setItem("refreshToken", refreshToken);
+      router.push("/dashboard");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "로그인에 실패했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <h1
+        style={{
+          fontSize: "1.5rem",
+          fontWeight: 700,
+          marginBottom: "2rem",
+          textAlign: "center",
+          color: "var(--text-primary)",
+        }}
+      >
+        로그인
+      </h1>
+
+      <form
+        onSubmit={onSubmit}
+        style={{ display: "flex", flexDirection: "column", gap: "1rem" }}
+      >
+        <input
+          type="text"
+          placeholder="아이디"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+          style={inputStyle}
+        />
+        <input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          style={inputStyle}
+        />
+
+        {error && (
+          <p style={{ color: "var(--price-up)", fontSize: "0.875rem", textAlign: "center" }}>
+            {error}
+          </p>
+        )}
+
+        <button type="submit" disabled={isLoading} style={buttonStyle}>
+          {isLoading ? "로그인 중..." : "로그인"}
+        </button>
+      </form>
+
+      <p
+        style={{
+          marginTop: "1.5rem",
+          textAlign: "center",
+          fontSize: "0.875rem",
+          color: "var(--text-tertiary)",
+        }}
+      >
+        계정이 없으신가요?{" "}
+        <Link href="/register" style={{ color: "var(--accent-primary)", fontWeight: 600 }}>
+          회원가입
+        </Link>
+      </p>
+    </>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  padding: "0.75rem 1rem",
+  borderRadius: "0.5rem",
+  border: "1px solid var(--border-soft)",
+  background: "var(--bg-card)",
+  fontSize: "1rem",
+  color: "var(--text-primary)",
+  outline: "none",
+  width: "100%",
+};
+
+const buttonStyle: React.CSSProperties = {
+  marginTop: "0.5rem",
+  padding: "0.875rem",
+  borderRadius: "0.5rem",
+  background: "var(--accent-primary)",
+  color: "#fff",
+  fontWeight: 700,
+  fontSize: "1rem",
+  cursor: "pointer",
+};

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Link from "next/link";
 import { fetchApi } from "@/lib/client";
-import { UsersRes } from "@/type/user";
+import { LoginReq, UsersRes } from "@/type/user";
 
 export default function LoginPage() {
   const router = useRouter();
@@ -20,7 +20,7 @@ export default function LoginPage() {
     try {
       const { accessToken, refreshToken } = await fetchApi("/api/users/login", {
         method: "POST",
-        body: JSON.stringify({ username, password }),
+        body: JSON.stringify({ username, password } as LoginReq),
       }) as UsersRes;
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -8,10 +8,13 @@ import { LoginReq, UsersRes } from "@/type/user";
 
 export default function LoginPage() {
   const router = useRouter();
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
+  const [form, setForm] = useState<LoginReq>({ username: "", password: "" });
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -20,7 +23,7 @@ export default function LoginPage() {
     try {
       const { accessToken, refreshToken } = await fetchApi("/api/users/login", {
         method: "POST",
-        body: JSON.stringify({ username, password } as LoginReq),
+        body: JSON.stringify(form),
       }) as UsersRes;
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
@@ -52,17 +55,19 @@ export default function LoginPage() {
       >
         <input
           type="text"
+          name="username"
           placeholder="아이디"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          value={form.username}
+          onChange={onChange}
           required
           style={inputStyle}
         />
         <input
           type="password"
+          name="password"
           placeholder="비밀번호"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          value={form.password}
+          onChange={onChange}
           required
           style={inputStyle}
         />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+export default function DashboardPage() {
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <p style={{ fontSize: "1.25rem", fontWeight: 600 }}>대시보드 (임시)</p>
+    </div>
+  );
+}

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -1,3 +1,8 @@
+export type LoginReq = {
+  username: string;
+  password: string;
+};
+
 export type SignupReq = {
   username: string;
   password: string;


### PR DESCRIPTION
## 📌 과제 설명
- 로그인 기능 구현 및 백엔드 API 연동

 ## 👩‍💻 요구 사항과 구현 내용
- 로그인 페이지 구현
  - 로그인 폼 UI 및 `POST /api/users/login` 연동, 토큰 localStorage 저장
- LoginReq 타입 추가 및 로그인 페이지에 적용
  - 로그인 요청 타입 정의
- 대시보드 임시 페이지 추가
  - 로그인 성공 후 이동 경로
- 로그인 폼 state를 LoginReq 타입으로 통합
  - 개별 state 대신 form 객체로 통합하여 타입 활용

## ✅ PR 포인트 & 궁금한 점
- 로그인 성공 시 accessToken, refreshToken을 localStorage에 저장합니다.
- 이후 모든 API 요청은 fetchApi 래퍼를 통해 공통 처리합니다.
- 회원가입 페이지랑 동일하게 form state 적용으로 일관성 유지했습니다.