### PR TITLE
Feature/au 05

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -21,10 +21,11 @@ export default function LoginPage() {
     setError("");
     setIsLoading(true);
     try {
-      const { accessToken, refreshToken } = await fetchApi("/api/users/login", {
+      const data: UsersRes = await fetchApi("/api/users/login", {
         method: "POST",
         body: JSON.stringify(form),
-      }) as UsersRes;
+      });
+      const { accessToken, refreshToken } = data;
       localStorage.setItem("accessToken", accessToken);
       localStorage.setItem("refreshToken", refreshToken);
       router.push("/dashboard");

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -142,5 +142,4 @@ const buttonStyle: React.CSSProperties = {
   fontWeight: 700,
   fontSize: "1rem",
   cursor: "pointer",
-  opacity: 1,
 };

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,19 +8,21 @@ export default function DashboardPage() {
   const router = useRouter();
 
   const onLogout = async () => {
-    const req: TokenReq = { refreshToken: localStorage.getItem("refreshToken") ?? "" };
-    try {
-      await fetchApi("/api/users/logout", {
-        method: "POST",
-        body: JSON.stringify(req),
-      });
-    } catch {
-      // 토큰이 만료되었거나 유효하지 않아도 로컬 토큰은 제거
-    } finally {
-      localStorage.removeItem("accessToken");
-      localStorage.removeItem("refreshToken");
-      router.push("/login");
+    const refreshToken = localStorage.getItem("refreshToken");
+    if (refreshToken) {
+      const req: TokenReq = { refreshToken };
+      try {
+        await fetchApi("/api/users/logout", {
+          method: "POST",
+          body: JSON.stringify(req),
+        });
+      } catch {
+        // 토큰이 만료되었거나 유효하지 않아도 로컬 토큰은 제거
+      }
     }
+    localStorage.removeItem("accessToken");
+    localStorage.removeItem("refreshToken");
+    router.push("/login");
   };
 
   return (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,16 +2,17 @@
 
 import { useRouter } from "next/navigation";
 import { fetchApi } from "@/lib/client";
+import { TokenReq } from "@/type/user";
 
 export default function DashboardPage() {
   const router = useRouter();
 
   const onLogout = async () => {
-    const refreshToken = localStorage.getItem("refreshToken");
+    const req: TokenReq = { refreshToken: localStorage.getItem("refreshToken") ?? "" };
     try {
       await fetchApi("/api/users/logout", {
         method: "POST",
-        body: JSON.stringify({ refreshToken }),
+        body: JSON.stringify(req),
       });
     } catch {
       // 토큰이 만료되었거나 유효하지 않아도 로컬 토큰은 제거

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,16 +1,53 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+import { fetchApi } from "@/lib/client";
+
 export default function DashboardPage() {
+  const router = useRouter();
+
+  const onLogout = async () => {
+    const refreshToken = localStorage.getItem("refreshToken");
+    try {
+      await fetchApi("/api/users/logout", {
+        method: "POST",
+        body: JSON.stringify({ refreshToken }),
+      });
+    } catch {
+      // 토큰이 만료되었거나 유효하지 않아도 로컬 토큰은 제거
+    } finally {
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("refreshToken");
+      router.push("/login");
+    }
+  };
+
   return (
     <div
       style={{
         flex: 1,
         display: "flex",
+        flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
+        gap: "1.5rem",
       }}
     >
       <p style={{ fontSize: "1.25rem", fontWeight: 600 }}>대시보드 (임시)</p>
+      <button
+        onClick={onLogout}
+        style={{
+          padding: "0.75rem 2rem",
+          borderRadius: "0.5rem",
+          background: "var(--accent-primary)",
+          color: "#fff",
+          fontWeight: 700,
+          fontSize: "1rem",
+          cursor: "pointer",
+        }}
+      >
+        로그아웃
+      </button>
     </div>
   );
 }

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -10,6 +10,10 @@ export type SignupReq = {
   nickname: string;
 };
 
+export type TokenReq = {
+  refreshToken: string;
+};
+
 export type UsersRes = {
   accessToken: string;
   refreshToken: string;


### PR DESCRIPTION
## 📌 과제 설명
  로그아웃 기능 구현 및 백엔드 API 연동

## 👩‍💻 요구 사항과 구현 내용
- TokenReq 타입 추가
  - 로그아웃/토큰 재발급 요청 타입 정의
- 대시보드 임시 페이지에 로그아웃 기능 추가
  - `POST /api/users/logout` 연동, localStorage 토큰 제거 후 로그인 페이지 이동
- as 캐스팅 제거 및 UsersRes 타입 명시적 선언으로 변경
  - 로그인 페이지 타입 적용 방식 개선
- refreshToken null 체크 추가 및 로직 개선
  - null일 경우 API 호출 없이 바로 토큰 제거 후 이동
- buttonStyle에서 불필요한 opacity 기본값 제거

## ✅ PR 포인트 & 궁금한 점
- 로그아웃 API 실패해도 로컬 토큰은 무조건 제거하여 클라이언트 인증 상태 초기화합니다.
- refreshToken이 없을 경우(NULL) API 호출 없이 그냥 로그인 페이지로 이동하게 했습니다.
- 전체적으로 DTO 사용 여부나 확장 때문에 불필요하게 넣어져 있던 부분들 확인했습니다.