### PR TITLE
feat: TR-01 매수 화면

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
   devIndicators: false,
+  async rewrites() {
+    return [
+      {
+        source: "/api/:path*",
+        destination: "http://localhost:8080/api/:path*",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/trade_buy/TradeBuyClient.tsx
+++ b/src/app/trade_buy/TradeBuyClient.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import styles from "./trade-buy.module.css";
+
+function formatKrw(n: number): string {
+  return `${n.toLocaleString("ko-KR")}원`;
+}
+
+function formatQtyDigits(raw: string): string {
+  if (!raw) return "";
+  return Number(raw).toLocaleString("ko-KR");
+}
+
+export default function TradeBuyClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const stockCode = searchParams.get("stockCode") ?? "005930";
+  const stockId = Number(searchParams.get("stockId") ?? "1");
+  const stockName = searchParams.get("stockName") ?? "삼성전자";
+
+  const [currentPrice, setCurrentPrice] = useState<number | null>(null);
+  const [changeSign, setChangeSign] = useState("");
+  const [changeRate, setChangeRate] = useState("");
+  const [qtyDigits, setQtyDigits] = useState("");
+  const [isBuying, setIsBuying] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback((msg: string) => {
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    setToast(msg);
+    toastTimer.current = setTimeout(() => setToast(null), 3000);
+  }, []);
+
+  const isButtonDisabled = currentPrice === null || qtyDigits === "" || isBuying;
+
+  const handleBuy = useCallback(async () => {
+    if (isButtonDisabled) return;
+
+    // 디바운싱: 마지막 클릭 후 300ms 내 재클릭 무시
+    if (debounceTimer.current) return;
+    debounceTimer.current = setTimeout(() => {
+      debounceTimer.current = null;
+    }, 300);
+
+    setIsBuying(true);
+    try {
+      const res = await fetch("/api/trades/buy?userId=1", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Idempotency-Key": crypto.randomUUID(),
+        },
+        body: JSON.stringify({ stockId, quantity: Number(qtyDigits) }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json();
+        showToast(err.message ?? "매수에 실패했습니다.");
+        return;
+      }
+
+      const result = await res.json();
+      const { stockName: name, quantity, price } = result.data;
+      showToast(
+        `${name} ${quantity.toLocaleString("ko-KR")}주 매수 완료 (${price.toLocaleString("ko-KR")}원)`,
+      );
+      setQtyDigits("");
+    } catch {
+      showToast("네트워크 오류가 발생했습니다.");
+    } finally {
+      setIsBuying(false);
+    }
+  }, [isButtonDisabled, stockId, qtyDigits, showToast]);
+
+  useEffect(() => {
+    const es = new EventSource(`http://localhost:8080/api/stocks/${stockCode}/sse`);
+
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      setCurrentPrice(Number(data.price));
+      setChangeSign(data.changeSign);
+      setChangeRate(data.changeRate);
+    };
+
+    es.onerror = () => es.close();
+
+    return () => es.close();
+  }, [stockCode]);
+
+  const appendDigit = useCallback((d: string) => {
+    setQtyDigits((prev) => {
+      if (prev.length >= 7) return prev;
+      if (prev === "0" && d !== "0") return d;
+      if (prev === "0" && d === "0") return prev;
+      return prev + d;
+    });
+  }, []);
+
+  const appendDoubleZero = useCallback(() => {
+    setQtyDigits((prev) => {
+      if (prev.length >= 6) return prev;
+      if (prev === "") return "";
+      return prev + "00";
+    });
+  }, []);
+
+  const backspace = useCallback(() => {
+    setQtyDigits((prev) => prev.slice(0, -1));
+  }, []);
+
+  const keys = useMemo(
+    () => [
+      ["1", "2", "3"],
+      ["4", "5", "6"],
+      ["7", "8", "9"],
+      ["00", "0", "back"],
+    ],
+    [],
+  );
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <div className={styles.topBar}>
+          <button
+            type="button"
+            className={styles.backBtn}
+            onClick={() => router.back()}
+            aria-label="뒤로 가기"
+          >
+            <span className={styles.backIcon} aria-hidden>
+              ←
+            </span>
+          </button>
+          <div className={styles.headerCenter}>
+            <p className={styles.stockName}>{stockName}</p>
+            <p className={styles.priceRow}>
+              {currentPrice !== null ? formatKrw(currentPrice) : "-"}
+              {changeRate && (
+                <span className={styles.change}>
+                  {["4", "5"].includes(changeSign) ? "-" : "+"}
+                  {changeRate}%
+                </span>
+              )}
+            </p>
+          </div>
+          <div className={styles.topBarSpacer} aria-hidden />
+        </div>
+      </header>
+
+      <div className={styles.body}>
+        <section className={styles.card} aria-label="구매 가격">
+          <p className={styles.priceLabel}>구매할 가격(시장가)</p>
+          <p className={styles.priceValue}>
+            {currentPrice !== null ? formatKrw(currentPrice) : "-"}
+          </p>
+        </section>
+
+        <section className={styles.card} aria-label="수량 입력">
+          <div className={styles.qtyPrompt}>
+            {qtyDigits ? (
+              <span>{formatQtyDigits(qtyDigits)}주</span>
+            ) : (
+              <>
+                <span className={styles.cursor} aria-hidden />
+                <span className={styles.qtyPlaceholder}>몇 주 구매할까요?</span>
+              </>
+            )}
+          </div>
+          <p className={styles.subInfo}>
+            {qtyDigits && currentPrice !== null
+              ? `총 ${formatKrw(Number(qtyDigits) * currentPrice)}`
+              : "구매가능 0원 · 최대 0주"}
+          </p>
+        </section>
+
+        <div className={styles.keypadWrap}>
+          <div className={styles.keypad} role="group" aria-label="숫자 키패드">
+            {keys.map((row, ri) =>
+              row.map((key) => (
+                <button
+                  key={`${ri}-${key}`}
+                  type="button"
+                  className={styles.key}
+                  onClick={() => {
+                    if (key === "back") backspace();
+                    else if (key === "00") appendDoubleZero();
+                    else appendDigit(key);
+                  }}
+                >
+                  {key === "back" ? (
+                    <span className={styles.keyIcon} aria-label="지우기">
+                      ⌫
+                    </span>
+                  ) : (
+                    key
+                  )}
+                </button>
+              )),
+            )}
+          </div>
+        </div>
+      </div>
+
+      {toast && <div className={styles.toast}>{toast}</div>}
+
+      <footer className={styles.footer}>
+        <button
+          type="button"
+          className={styles.buyBtn}
+          onClick={handleBuy}
+          disabled={isButtonDisabled}
+        >
+          {isBuying ? "처리 중..." : "구매하기"}
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/trade_buy/page.tsx
+++ b/src/app/trade_buy/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import type { Metadata } from "next";
+import TradeBuyClient from "./TradeBuyClient";
+
+export const metadata: Metadata = {
+  title: "구매 | Together FE",
+  description: "주식 구매 화면",
+};
+
+export default function TradeBuyPage() {
+  return (
+    <Suspense>
+      <TradeBuyClient />
+    </Suspense>
+  );
+}

--- a/src/app/trade_buy/trade-buy.module.css
+++ b/src/app/trade_buy/trade-buy.module.css
@@ -1,0 +1,238 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-page);
+  color: var(--text-primary);
+}
+
+.header {
+  padding: 0.625rem 0.5rem 0.75rem;
+}
+
+.topBar {
+  display: grid;
+  grid-template-columns: 2.75rem minmax(0, 1fr) 2.75rem;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.backBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.backBtn:active {
+  background: rgba(17, 17, 17, 0.06);
+}
+
+.backIcon {
+  font-size: 1.375rem;
+  line-height: 1;
+  font-weight: 500;
+}
+
+.headerCenter {
+  text-align: center;
+  min-width: 0;
+}
+
+.topBarSpacer {
+  width: 2.75rem;
+  height: 2.75rem;
+  justify-self: end;
+}
+
+.stockName {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 0.375rem;
+}
+
+.priceRow {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--price-up);
+}
+
+.change {
+  margin-left: 0.375rem;
+  font-weight: 600;
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 0 1rem;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+}
+
+.card {
+  background: #ffffff;
+  border: 1px solid var(--border-soft);
+  border-radius: 0.75rem;
+  padding: 0.875rem 1rem;
+  box-shadow: 0 1px 2px rgba(17, 17, 17, 0.04);
+}
+
+.priceLabel {
+  margin-bottom: 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.priceValue {
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+}
+
+.qtyPrompt {
+  min-height: 1.75rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.125rem;
+}
+
+.qtyPlaceholder {
+  color: var(--text-disabled);
+  font-weight: 500;
+}
+
+.cursor {
+  display: inline-block;
+  flex-shrink: 0;
+  width: 2px;
+  height: 1.125rem;
+  background: var(--price-down);
+  margin-right: 0.125rem;
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+.subInfo {
+  margin-top: 0.625rem;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.keypadWrap {
+  width: 100%;
+  margin-top: auto;
+  margin-inline: 0;
+  padding: 1.5rem 0.75rem 1rem;
+  box-sizing: border-box;
+}
+
+.keypad {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem 0.875rem;
+  width: 100%;
+  max-width: 100%;
+  margin-inline: auto;
+  justify-items: stretch;
+  align-items: stretch;
+}
+
+.key {
+  min-height: 3.25rem;
+  padding: 0.875rem 0.625rem;
+  border-radius: 0.625rem;
+  background: var(--bg-section);
+  border: 1px solid var(--border-soft);
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s ease;
+}
+
+.key:active {
+  background: var(--cream);
+}
+
+.keyIcon {
+  font-size: 1.125rem;
+  line-height: 1;
+}
+
+.footer {
+  padding: 0.75rem 1rem 1.25rem;
+  background: linear-gradient(to top, var(--bg-page) 70%, transparent);
+}
+
+.buyBtn {
+  width: 100%;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  background: var(--price-up);
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(229, 57, 53, 0.25);
+}
+
+.buyBtn:active {
+  opacity: 0.92;
+}
+
+.buyBtn:disabled {
+  background: var(--border-strong);
+  box-shadow: none;
+  cursor: not-allowed;
+  opacity: 1;
+}
+
+.toast {
+  position: fixed;
+  bottom: 5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #111111;
+  color: #ffffff;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.75rem 1.25rem;
+  border-radius: 2rem;
+  white-space: nowrap;
+  z-index: 200;
+  animation: toastIn 0.2s ease, toastOut 0.3s ease 2.7s forwards;
+}
+
+@keyframes toastIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(0.5rem); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+@keyframes toastOut {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}


### PR DESCRIPTION
## 📌 과제 설명
 매수 화면 구현과 하드코딩되어 있던 현재가, 종목명 등의 값을 백엔드 API와 실제로 연동

## 👩‍💻 요구 사항과 구현 내용>
  - [x] URL 파라미터(stockCode, stockId, stockName)로 종목 정보 수신
  - [x] SSE로 실시간 현재가/등락률 연동 (백엔드 직접 호출 - 프록시 버퍼링 이슈)
  - [x] 수량 입력 시 총 매수금액 실시간 표시
  - [x] 매수 API 연결 - X-Idempotency-Key 헤더, 디바운싱(300ms), 처리 중 버튼 비활성화
  - [x] 매수 성공/실패 결과 토스트 알림으로 표시

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
  - SSE는 Next.js rewrite 프록시가 스트리밍을 버퍼링하는 문제로 백엔드(localhost:8080)를 직접 호출하도록 처리했습니다.
    (배포 환경에서는 별도 처리가 필요할 것 같습니다.)
  - userId는 현재 임시로 1로 고정되어 있으며, Security 적용 후 교체 예정입니다.

<img width="319" height="471" alt="image" src="https://github.com/user-attachments/assets/46fe37e2-9b4b-4b0f-8e03-1c1750710d2d" />

