### PR TITLE
Feature/sec

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -25,9 +25,7 @@ export default function LoginPage() {
         method: "POST",
         body: JSON.stringify(form),
       });
-      const { accessToken, refreshToken } = data;
-      localStorage.setItem("accessToken", accessToken);
-      localStorage.setItem("refreshToken", refreshToken);
+      localStorage.setItem("accessToken", data.accessToken);
       router.push("/dashboard");
     } catch (err) {
       setError(err instanceof Error ? err.message : "로그인에 실패했습니다.");

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { fetchApi } from "@/lib/client";
 import { SignupReq } from "@/type/user";
+import RegisterSuccessModal from "@/components/RegisterSuccessModal";
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -15,6 +16,7 @@ export default function RegisterPage() {
     nickname: "",
   });
   const [error, setError] = useState("");
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,8 +32,7 @@ export default function RegisterPage() {
         method: "POST",
         body: JSON.stringify(form),
       });
-      alert("회원가입이 완료되었습니다.");
-      router.push("/login");
+      setShowSuccessModal(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : "회원가입에 실패했습니다.");
     } finally {
@@ -41,6 +42,9 @@ export default function RegisterPage() {
 
   return (
     <>
+      {showSuccessModal && (
+        <RegisterSuccessModal onConfirm={() => router.push("/login")} />
+      )}
       <h1
         style={{
           fontSize: "1.5rem",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,26 +2,19 @@
 
 import { useRouter } from "next/navigation";
 import { fetchApi } from "@/lib/client";
-import { TokenReq } from "@/type/user";
 
 export default function DashboardPage() {
   const router = useRouter();
 
   const onLogout = async () => {
-    const refreshToken = localStorage.getItem("refreshToken");
-    if (refreshToken) {
-      const req: TokenReq = { refreshToken };
-      try {
-        await fetchApi("/api/users/logout", {
-          method: "POST",
-          body: JSON.stringify(req),
-        });
-      } catch {
-        // 토큰이 만료되었거나 유효하지 않아도 로컬 토큰은 제거
-      }
+    try {
+      await fetchApi("/api/users/logout", {
+        method: "POST",
+      });
+    } catch {
+      // 토큰이 만료되었거나 유효하지 않아도 로컬 토큰은 제거
     }
     localStorage.removeItem("accessToken");
-    localStorage.removeItem("refreshToken");
     router.push("/login");
   };
 

--- a/src/app/trade_buy/TradeBuyClient.tsx
+++ b/src/app/trade_buy/TradeBuyClient.tsx
@@ -49,11 +49,13 @@ export default function TradeBuyClient() {
 
     setIsBuying(true);
     try {
-      const res = await fetch("/api/trades/buy?userId=1", {
+      const accessToken = localStorage.getItem("accessToken");
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/trades/buy`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           "X-Idempotency-Key": crypto.randomUUID(),
+          Authorization: `Bearer ${accessToken}`,
         },
         body: JSON.stringify({ stockId, quantity: Number(qtyDigits) }),
       });
@@ -78,7 +80,7 @@ export default function TradeBuyClient() {
   }, [isButtonDisabled, stockId, qtyDigits, showToast]);
 
   useEffect(() => {
-    const es = new EventSource(`http://localhost:8080/api/stocks/${stockCode}/sse`);
+    const es = new EventSource(`${process.env.NEXT_PUBLIC_API_BASE_URL}/api/stocks/${stockCode}/sse`);
 
     es.onmessage = (e) => {
       const data = JSON.parse(e.data);

--- a/src/components/RegisterSuccessModal.tsx
+++ b/src/components/RegisterSuccessModal.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+interface Props {
+  onConfirm: () => void;
+}
+
+export default function RegisterSuccessModal({ onConfirm }: Props) {
+  return (
+    <div style={backdropStyle}>
+      <div style={modalStyle}>
+        <h1 style={titleStyle}>회원가입 완료</h1>
+        <p style={descStyle}>
+          환영합니다!
+          <br />
+          귀하의 계정이 성공적으로 생성되었습니다.
+          <br />
+          <span style={{ fontWeight: 700, color: "var(--accent-primary)" }}>
+            예수금 5천만원이 지급되었습니다.
+          </span>
+        </p>
+        <button style={buttonStyle} onClick={onConfirm}>
+          로그인하러 가기
+        </button>
+        <div style={gradientBarStyle} />
+      </div>
+    </div>
+  );
+}
+
+const backdropStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(17, 28, 50, 0.4)",
+  backdropFilter: "blur(4px)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 50,
+};
+
+const modalStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "24rem",
+  background: "var(--mobile-surface)",
+  borderRadius: "0.75rem",
+  boxShadow: "0 20px 50px rgba(17,28,50,0.12)",
+  overflow: "hidden",
+  padding: "2.5rem 2rem 0",
+  textAlign: "center",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "1.5rem",
+  fontWeight: 800,
+  color: "var(--text-primary)",
+  marginBottom: "0.75rem",
+};
+
+const descStyle: React.CSSProperties = {
+  fontSize: "0.9375rem",
+  lineHeight: 1.7,
+  color: "var(--text-secondary)",
+  marginBottom: "2rem",
+};
+
+const buttonStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "0.875rem",
+  borderRadius: "0.5rem",
+  background: "var(--accent-primary)",
+  color: "#fff",
+  fontWeight: 700,
+  fontSize: "1rem",
+  cursor: "pointer",
+  marginBottom: "2rem",
+};
+
+const gradientBarStyle: React.CSSProperties = {
+  height: "4px",
+  background: "linear-gradient(to right, var(--price-down), var(--accent-primary), var(--price-up))",
+  margin: "0 -2rem",
+};

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -8,6 +8,7 @@ export function fetchApi(url: string, options?: RequestInit) {
   }
 
   options.headers = headers;
+  options.credentials = "include";
 
   return fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}${url}`, options).then(
     async (res) => {

--- a/src/type/user.ts
+++ b/src/type/user.ts
@@ -10,11 +10,6 @@ export type SignupReq = {
   nickname: string;
 };
 
-export type TokenReq = {
-  refreshToken: string;
-};
-
 export type UsersRes = {
   accessToken: string;
-  refreshToken: string;
 };


### PR DESCRIPTION
## 📌 과제 설명
- 백엔드 HttpOnly 쿠키에 맞춰서 프론트엔드 연동 방식 수정
- `refreshToken`을 localStorage에서 완전히 제거, `accessToken`만 클라이언트에서 관리
- 회원가입 완료 팝업 복구

## 👩‍💻 요구 사항과 구현 내용
- fetchApi에 `credentials include` 추가
  - 모든 API 요청에 쿠키가 자동으로 전송되도록 설정. HttpOnly 쿠키 기반 refreshToken 연동의 전제 조건.
- `UsersRes`에서 `refreshToken` 제거, `TokenReq` 삭제
  - 백엔드 응답 구조 변경에 맞춰 타입 정리.
- 로그인 페이지에서 refreshToken localStorage 저장 제거
  - accessToken만 localStorage에 저장. refreshToken은 서버가 쿠키로 직접 설정.
- 로그아웃을 HttpOnly 쿠키 방식으로 전환
  - body에 refreshToken을 담는 방식 제거. 쿠키가 자동으로 전송되므로 body 없이 요청.
- 거래 페이지 인증 헤더 추가 및 하드코딩 URL 제거
  - `?userId=1` 제거, `Authorization: Bearer` 추가. EventSource URL을 env 변수로 교체.

## ✅ PR 포인트 & 궁금한 점
- refreshToken은 JS에서 전혀 접근하지 않으며, 브라우저가 쿠키를 자동으로 붙여서 전송합니다.
- 현재 인증이 필요한 페이지에 대한 라우트 가드가 없습니다. 로그인 없이 URL 직접 접근 시 서버에서 401을 내려주긴 하지만 프론트에서 별도 처리가 없는 상태입니다. 별도 이슈로 논의가 필요합니다.