### PR TITLE
fix: 전일 대비율 소수점 둘째자리 표시

### DIFF
--- a/src/app/stock/[stockCode]/page.tsx
+++ b/src/app/stock/[stockCode]/page.tsx
@@ -222,7 +222,7 @@ export default function StockDetailPage() {
                                 className="text-sm"
                                 style={{ color: isPositive ? 'var(--price-up)' : 'var(--price-down)' }}
                             >
-                                ({isPositive ? '+' : ''}{Number(priceInfo?.changeRate ?? 0).toFixed(1)}%)
+                                ({isPositive ? '+' : ''}{Number(priceInfo?.changeRate ?? 0).toFixed(2)}%)
                             </span>
                             <span className="text-xs ml-1" style={{ color: 'var(--text-tertiary)' }}>
                                 전일 대비


### PR DESCRIPTION
## 📌 과제 설명 
특정 종목 조회 페이지
- 전일 대비율 소수점 둘째자리까지 표시
## 👩‍💻 요구 사항과 구현 내용 
fix: 전일 대비율 소수점 둘째자리 표시